### PR TITLE
add RushingStatistics search by players' name

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,6 +1,6 @@
 {
   "coverage_options": {
-    "minimum_coverage": 78.7
+    "minimum_coverage": 79.7
   },
   "skip_files": []
 }

--- a/lib/nfl_rushing.ex
+++ b/lib/nfl_rushing.ex
@@ -1,8 +1,15 @@
 defmodule NflRushing do
   @moduledoc false
+  import Ecto.Query
 
   alias NflRushing.{Repo, RushingStatistics}
 
-  @spec list_rushing_statistics :: list(RushingStatistics.t())
-  def list_rushing_statistics, do: Repo.all(RushingStatistics)
+  @spec search_rushing_statistics(String.t()) :: list(RushingStatistics.t())
+  def search_rushing_statistics(player_name \\ "%") do
+    search_name = "%#{player_name}%"
+
+    RushingStatistics
+    |> where([s], like(s.name, ^search_name))
+    |> Repo.all()
+  end
 end

--- a/lib/nfl_rushing_web/live/rushing_statistics_live.ex
+++ b/lib/nfl_rushing_web/live/rushing_statistics_live.ex
@@ -5,13 +5,12 @@ defmodule NflRushingWeb.RushingStatisticsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    Process.send(self(), :update, [])
     {:ok, assign(socket, rushing_statistics: [])}
   end
 
   @impl true
-  def handle_info(:update, socket) do
-    stats = NflRushing.list_rushing_statistics()
+  def handle_params(params, _uri, socket) do
+    stats = NflRushing.search_rushing_statistics(params["search"])
     {:noreply, assign(socket, rushing_statistics: stats)}
   end
 end

--- a/lib/nfl_rushing_web/live/rushing_statistics_live.ex
+++ b/lib/nfl_rushing_web/live/rushing_statistics_live.ex
@@ -5,12 +5,19 @@ defmodule NflRushingWeb.RushingStatisticsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, rushing_statistics: [])}
+    {:ok, assign(socket, rushing_statistics: [], search: nil)}
   end
 
   @impl true
   def handle_params(params, _uri, socket) do
-    stats = NflRushing.search_rushing_statistics(params["search"])
-    {:noreply, assign(socket, rushing_statistics: stats)}
+    search = params["search"]
+    stats = NflRushing.search_rushing_statistics(search)
+    {:noreply, assign(socket, rushing_statistics: stats, search: search)}
+  end
+
+  @impl true
+  def handle_event("search", %{"q" => name}, socket) do
+    {:noreply,
+     push_redirect(socket, to: Routes.rushing_statistics_path(socket, :index, search: name))}
   end
 end

--- a/lib/nfl_rushing_web/live/rushing_statistics_live.html.leex
+++ b/lib/nfl_rushing_web/live/rushing_statistics_live.html.leex
@@ -1,3 +1,11 @@
-<section class="statistics">
+<section class="row">
+  <div class="column">
+    <form phx-submit="search">
+      <input type="text" name="q" value="<%= @search %>" placeholder="Player's name" autocomplete="on"/>
+      <button type="submit" phx-disable-with="Searching...">Search</button>
+    </form>
+  </div>
+</section>
+<section name="statistics" class="row">
   <%= live_component NflRushingWeb.StatisticsComponent, rushing_statistics: @rushing_statistics %>
 </section>

--- a/test/nfl_rushing_test.exs
+++ b/test/nfl_rushing_test.exs
@@ -18,7 +18,7 @@ defmodule NflRushingTest do
       assert NflRushing.search_rushing_statistics("john") == []
     end
 
-    test "finds all rushing statistics" do
+    test "finds only rushing statistics by players' name" do
       stat_one = insert!(:rushing_statistics, %{name: "John Stone"})
       _stat_two = insert!(:rushing_statistics, %{name: "Max Smith"})
       assert NflRushing.search_rushing_statistics("john") == [stat_one]

--- a/test/nfl_rushing_test.exs
+++ b/test/nfl_rushing_test.exs
@@ -1,15 +1,27 @@
 defmodule NflRushingTest do
   use NflRushing.DataCase
 
-  describe "list_rushing_statistics/0" do
+  describe "search_rushing_statistics/0" do
     test "finds no rushing statistics" do
-      assert NflRushing.list_rushing_statistics() == []
+      assert NflRushing.search_rushing_statistics() == []
     end
 
     test "finds all rushing statistics" do
       stat_one = insert!(:rushing_statistics)
       stat_two = insert!(:rushing_statistics)
-      assert NflRushing.list_rushing_statistics() == [stat_one, stat_two]
+      assert NflRushing.search_rushing_statistics() == [stat_one, stat_two]
+    end
+  end
+
+  describe "search_rushing_statistics/1" do
+    test "finds no rushing statistics" do
+      assert NflRushing.search_rushing_statistics("john") == []
+    end
+
+    test "finds all rushing statistics" do
+      stat_one = insert!(:rushing_statistics, %{name: "John Stone"})
+      _stat_two = insert!(:rushing_statistics, %{name: "Max Smith"})
+      assert NflRushing.search_rushing_statistics("john") == [stat_one]
     end
   end
 end

--- a/test/nfl_rushing_web/live/rushing_statistics_live_test.exs
+++ b/test/nfl_rushing_web/live/rushing_statistics_live_test.exs
@@ -30,4 +30,15 @@ defmodule NflRushingWeb.RushingStatisticsLiveTest do
     assert render(live) =~ "<td>John Stone</td>"
     refute render(live) =~ "<td>Max Smith</td>"
   end
+
+  describe "handle_event/2 for search" do
+    test "redirects to searched players' rushing statistics", %{conn: conn} do
+      {:ok, live, _disconnected} = live(conn, "/")
+
+      {:error, {:live_redirect, %{kind: :push, to: "/?search=john"}}} =
+        live
+        |> element("form")
+        |> render_submit(%{q: "john"})
+    end
+  end
 end

--- a/test/nfl_rushing_web/live/rushing_statistics_live_test.exs
+++ b/test/nfl_rushing_web/live/rushing_statistics_live_test.exs
@@ -13,12 +13,21 @@ defmodule NflRushingWeb.RushingStatisticsLiveTest do
     assert render(live) =~ "<tr></tr>"
   end
 
-  test "renders some rushing statistics", %{conn: conn} do
-    stat_one = insert!(:rushing_statistics)
-    stat_two = insert!(:rushing_statistics, %{name: "Max Smith"})
+  test "renders all rushing statistics", %{conn: conn} do
+    _stat_one = insert!(:rushing_statistics, %{name: "John Stone"})
+    _stat_two = insert!(:rushing_statistics, %{name: "Max Smith"})
     {:ok, live, _disconnected} = live(conn, "/")
 
-    assert render(live) =~ "<td>#{stat_one.name}</td>"
-    assert render(live) =~ "<td>#{stat_two.name}</td>"
+    assert render(live) =~ "<td>John Stone</td>"
+    assert render(live) =~ "<td>Max Smith</td>"
+  end
+
+  test "renders only searched players' rushing statistics", %{conn: conn} do
+    _stat_one = insert!(:rushing_statistics, %{name: "John Stone"})
+    _stat_two = insert!(:rushing_statistics, %{name: "Max Smith"})
+    {:ok, live, _disconnected} = live(conn, "/?search=john")
+
+    assert render(live) =~ "<td>John Stone</td>"
+    refute render(live) =~ "<td>Max Smith</td>"
   end
 end


### PR DESCRIPTION
**Why?**

- To support the third feature, a.k.a `The user should be able to filter by the player's name`

**How?**

- refactor `NflRushing.list_rushing_statistics/0` to `NflRushing.search_rushing_statistics/1`;
- add search form on index view.